### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/ArrayDeque.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/ArrayDeque.java
@@ -59,6 +59,12 @@ import java.util.NoSuchElementException;
  */
 public class ArrayDeque<E> extends AbstractCollection<E>
         implements Deque<E>, Cloneable, java.io.Serializable {
+
+    /**
+     * Appease the serialization gods.
+     */
+    private static final long serialVersionUID = 2340985798034038923L;
+
     /**
      * The array in which the elements of the deque are stored.
      * The capacity of the deque is the length of this array, which is
@@ -89,6 +95,39 @@ public class ArrayDeque<E> extends AbstractCollection<E>
      * Must be a power of 2.
      */
     private static final int MIN_INITIAL_CAPACITY = 8;
+
+    /**
+     * Constructs an empty array deque with an initial capacity
+     * sufficient to hold 16 elements.
+     */
+    public ArrayDeque() {
+        elements = new Object[16];
+    }
+
+    /**
+     * Constructs an empty array deque with an initial capacity
+     * sufficient to hold the specified number of elements.
+     *
+     * @param numElements lower bound on initial capacity of the deque
+     */
+    public ArrayDeque(int numElements) {
+        allocateElements(numElements);
+    }
+
+    /**
+     * Constructs a deque containing the elements of the specified
+     * collection, in the order they are returned by the collection's
+     * iterator.  (The first element returned by the collection's
+     * iterator becomes the first element, or <i>front</i> of the
+     * deque.)
+     *
+     * @param c the collection whose elements are to be placed into the deque
+     * @throws NullPointerException if the specified collection is null
+     */
+    public ArrayDeque(Collection<? extends E> c) {
+        allocateElements(c.size());
+        addAll(c);
+    }
 
     // ******  Array allocation and resizing utilities ******
 
@@ -152,39 +191,6 @@ public class ArrayDeque<E> extends AbstractCollection<E>
             System.arraycopy(elements, 0, a, headPortionLen, tail);
         }
         return a;
-    }
-
-    /**
-     * Constructs an empty array deque with an initial capacity
-     * sufficient to hold 16 elements.
-     */
-    public ArrayDeque() {
-        elements = new Object[16];
-    }
-
-    /**
-     * Constructs an empty array deque with an initial capacity
-     * sufficient to hold the specified number of elements.
-     *
-     * @param numElements lower bound on initial capacity of the deque
-     */
-    public ArrayDeque(int numElements) {
-        allocateElements(numElements);
-    }
-
-    /**
-     * Constructs a deque containing the elements of the specified
-     * collection, in the order they are returned by the collection's
-     * iterator.  (The first element returned by the collection's
-     * iterator becomes the first element, or <i>front</i> of the
-     * deque.)
-     *
-     * @param c the collection whose elements are to be placed into the deque
-     * @throws NullPointerException if the specified collection is null
-     */
-    public ArrayDeque(Collection<? extends E> c) {
-        allocateElements(c.size());
-        addAll(c);
     }
 
     // The main insertion and extraction methods are addFirst,
@@ -804,11 +810,6 @@ public class ArrayDeque<E> extends AbstractCollection<E>
             throw new AssertionError();
         }
     }
-
-    /**
-     * Appease the serialization gods.
-     */
-    private static final long serialVersionUID = 2340985798034038923L;
 
     /**
      * Serialize this deque.

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFCore.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFCore.java
@@ -22,6 +22,23 @@ public class MuPDFCore {
     private byte[] fileBuffer;
     private String file_format;
 
+    public MuPDFCore(Context context, String filename) throws Exception {
+        globals = openFile(filename);
+        if (globals == 0) {
+            throw new Exception(String.format(context.getString(R.string.cannot_open_file_Path), filename));
+        }
+        file_format = fileFormatInternal();
+    }
+
+    public MuPDFCore(Context context, byte[] buffer) throws Exception {
+        fileBuffer = buffer;
+        globals = openBuffer();
+        if (globals == 0) {
+            throw new Exception(context.getString(R.string.cannot_open_buffer));
+        }
+        file_format = fileFormatInternal();
+    }
+
     /* The native functions */
     private native long openFile(String filename);
 
@@ -103,23 +120,6 @@ public class MuPDFCore {
     private native void saveInternal();
 
     public static native boolean javascriptSupported();
-
-    public MuPDFCore(Context context, String filename) throws Exception {
-        globals = openFile(filename);
-        if (globals == 0) {
-            throw new Exception(String.format(context.getString(R.string.cannot_open_file_Path), filename));
-        }
-        file_format = fileFormatInternal();
-    }
-
-    public MuPDFCore(Context context, byte[] buffer) throws Exception {
-        fileBuffer = buffer;
-        globals = openBuffer();
-        if (globals == 0) {
-            throw new Exception(context.getString(R.string.cannot_open_buffer));
-        }
-        file_format = fileFormatInternal();
-    }
 
     public int countPages() {
         if (numPages < 0)

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFReaderView.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFReaderView.java
@@ -18,6 +18,29 @@ public class MuPDFReaderView extends ReaderView {
     private boolean tapDisabled = false;
     private int tapPageMargin;
 
+    private float mX, mY;
+
+    private static final float TOUCH_TOLERANCE = 2;
+
+    public MuPDFReaderView(Activity act) {
+        super(act);
+        mContext = act;
+        // Get the screen size etc to customise tap margins.
+        // We calculate the size of 1 inch of the screen for tapping.
+        // On some devices the dpi values returned are wrong, so we
+        // sanity check it: we first restrict it so that we are never
+        // less than 100 pixels (the smallest Android device screen
+        // dimension I've seen is 480 pixels or so). Then we check
+        // to ensure we are never more than 1/5 of the screen width.
+        DisplayMetrics dm = new DisplayMetrics();
+        act.getWindowManager().getDefaultDisplay().getMetrics(dm);
+        tapPageMargin = (int) dm.xdpi;
+        if (tapPageMargin < 100)
+            tapPageMargin = 100;
+        if (tapPageMargin > dm.widthPixels / 5)
+            tapPageMargin = dm.widthPixels / 5;
+    }
+
     protected void onTapMainDocArea() {
     }
 
@@ -38,24 +61,6 @@ public class MuPDFReaderView extends ReaderView {
         mMode = m;
     }
 
-    public MuPDFReaderView(Activity act) {
-        super(act);
-        mContext = act;
-        // Get the screen size etc to customise tap margins.
-        // We calculate the size of 1 inch of the screen for tapping.
-        // On some devices the dpi values returned are wrong, so we
-        // sanity check it: we first restrict it so that we are never
-        // less than 100 pixels (the smallest Android device screen
-        // dimension I've seen is 480 pixels or so). Then we check
-        // to ensure we are never more than 1/5 of the screen width.
-        DisplayMetrics dm = new DisplayMetrics();
-        act.getWindowManager().getDefaultDisplay().getMetrics(dm);
-        tapPageMargin = (int) dm.xdpi;
-        if (tapPageMargin < 100)
-            tapPageMargin = 100;
-        if (tapPageMargin > dm.widthPixels / 5)
-            tapPageMargin = dm.widthPixels / 5;
-    }
 
     public boolean onSingleTapUp(MotionEvent e) {
         LinkInfo link;
@@ -169,10 +174,6 @@ public class MuPDFReaderView extends ReaderView {
 
         return super.onTouchEvent(event);
     }
-
-    private float mX, mY;
-
-    private static final float TOUCH_TOLERANCE = 2;
 
     private void touch_start(float x, float y) {
 

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/SearchTask.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/SearchTask.java
@@ -8,11 +8,11 @@ import android.graphics.RectF;
 import android.os.Handler;
 
 class ProgressDialogX extends ProgressDialog {
+    private boolean mCancelled = false;
+
     public ProgressDialogX(Context context) {
         super(context);
     }
-
-    private boolean mCancelled = false;
 
     public boolean isCancelled() {
         return mCancelled;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed
