### PR TITLE
Code quality fix - Array designators "[]" should be on the type, not the variable.

### DIFF
--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFActivity.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFActivity.java
@@ -118,7 +118,7 @@ public class MuPDFActivity extends Activity {
                 // core.waitForAlert may return null when shutting down
                 if (result == null)
                     return;
-                final MuPDFAlert.ButtonPressed pressed[] = new MuPDFAlert.ButtonPressed[3];
+                final MuPDFAlert.ButtonPressed[] pressed = new MuPDFAlert.ButtonPressed[3];
                 for (int i = 0; i < 3; i++)
                     pressed[i] = MuPDFAlert.ButtonPressed.None;
                 DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
@@ -224,7 +224,7 @@ public class MuPDFActivity extends Activity {
         return core;
     }
 
-    private MuPDFCore openBuffer(byte buffer[]) {
+    private MuPDFCore openBuffer(byte[] buffer) {
         System.out.println("Trying to open byte buffer");
         try {
             core = new MuPDFCore(this, buffer);
@@ -255,7 +255,7 @@ public class MuPDFActivity extends Activity {
         }
         if (core == null) {
             Intent intent = getIntent();
-            byte buffer[] = null;
+            byte[] buffer = null;
             if (Intent.ACTION_VIEW.equals(intent.getAction())) {
                 Uri uri = intent.getData();
                 if (uri.toString().startsWith("content://")) {
@@ -548,7 +548,7 @@ public class MuPDFActivity extends Activity {
         if (core.hasOutline()) {
             mOutlineButton.setOnClickListener(new View.OnClickListener() {
                 public void onClick(View v) {
-                    OutlineItem outline[] = core.getOutline();
+                    OutlineItem[] outline = core.getOutline();
                     if (outline != null) {
                         OutlineActivityData.get().items = outline;
                         Intent intent = new Intent(MuPDFActivity.this, OutlineActivity.class);

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFCore.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFCore.java
@@ -19,7 +19,7 @@ public class MuPDFCore {
     private float pageWidth;
     private float pageHeight;
     private long globals;
-    private byte fileBuffer[];
+    private byte[] fileBuffer;
     private String file_format;
 
     /* The native functions */
@@ -112,7 +112,7 @@ public class MuPDFCore {
         file_format = fileFormatInternal();
     }
 
-    public MuPDFCore(Context context, byte buffer[]) throws Exception {
+    public MuPDFCore(Context context, byte[] buffer) throws Exception {
         fileBuffer = buffer;
         globals = openBuffer();
         if (globals == 0) {

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFPageView.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFPageView.java
@@ -62,8 +62,8 @@ class PassClickResultChoice extends PassClickResult {
 public class MuPDFPageView extends PageView implements MuPDFView {
     private final MuPDFCore mCore;
     private AsyncTask<Void, Void, PassClickResult> mPassClick;
-    private RectF mWidgetAreas[];
-    private Annotation mAnnotations[];
+    private RectF[] mWidgetAreas;
+    private Annotation[] mAnnotations;
     private int mSelectedAnnotationIndex = -1;
     private AsyncTask<Void, Void, RectF[]> mLoadWidgetAreas;
     private AsyncTask<Void, Void, Annotation[]> mLoadAnnotations;

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFView.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/MuPDFView.java
@@ -28,7 +28,7 @@ public interface MuPDFView {
 
     public void deleteSelectedAnnotation();
 
-    public void setSearchBoxes(RectF searchBoxes[]);
+    public void setSearchBoxes(RectF[] searchBoxes);
 
     public void setLinkHighlighting(boolean f);
 

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/OutlineActivity.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/OutlineActivity.java
@@ -6,7 +6,7 @@ import android.view.View;
 import android.widget.ListView;
 
 public class OutlineActivity extends ListActivity {
-    OutlineItem mItems[];
+    OutlineItem[] mItems;
 
     /**
      * Called when the activity is first created.

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/OutlineActivityData.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/OutlineActivityData.java
@@ -1,7 +1,7 @@
 package com.artifex.mupdfdemo;
 
 public class OutlineActivityData {
-    public OutlineItem items[];
+    public OutlineItem[] items;
     public int position;
     static private OutlineActivityData singleton;
 

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/OutlineAdapter.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/OutlineAdapter.java
@@ -7,10 +7,10 @@ import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 public class OutlineAdapter extends BaseAdapter {
-    private final OutlineItem mItems[];
+    private final OutlineItem[] mItems;
     private final LayoutInflater mInflater;
 
-    public OutlineAdapter(LayoutInflater inflater, OutlineItem items[]) {
+    public OutlineAdapter(LayoutInflater inflater, OutlineItem[] items) {
         mInflater = inflater;
         mItems = items;
     }

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/PageView.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/PageView.java
@@ -127,10 +127,10 @@ public abstract class PageView extends ViewGroup {
     private ImageView mPatch;
     private BitmapHolder mPatchBmh;
     private AsyncTask<PatchInfo, Void, PatchInfo> mDrawPatch;
-    private RectF mSearchBoxes[];
-    protected LinkInfo mLinks[];
+    private RectF[] mSearchBoxes;
+    protected LinkInfo[] mLinks;
     private RectF mSelectBox;
-    private TextWord mText[][];
+    private TextWord[][] mText;
     private RectF mItemSelectBox;
     protected ArrayList<ArrayList<PointF>> mDrawing;
     private View mSearchView;
@@ -404,7 +404,7 @@ public abstract class PageView extends ViewGroup {
         requestLayout();
     }
 
-    public void setSearchBoxes(RectF searchBoxes[]) {
+    public void setSearchBoxes(RectF[] searchBoxes) {
         mSearchBoxes = searchBoxes;
         if (mSearchView != null)
             mSearchView.invalidate();

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/ReaderView.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/ReaderView.java
@@ -572,7 +572,7 @@ public class ReaderView
 
             // Remove not needed children and hold them for reuse
             int numChildren = mChildViews.size();
-            int childIndices[] = new int[numChildren];
+            int[] childIndices = new int[numChildren];
             for (int i = 0; i < numChildren; i++)
                 childIndices[i] = mChildViews.keyAt(i);
 

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/SearchTask.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/SearchTask.java
@@ -74,7 +74,7 @@ public abstract class SearchTask {
 
                 while (0 <= index && index < mCore.countPages() && !isCancelled()) {
                     publishProgress(index);
-                    RectF searchHits[] = mCore.searchPage(index, text);
+                    RectF[] searchHits = mCore.searchPage(index, text);
 
                     if (searchHits != null && searchHits.length > 0)
                         return new SearchTaskResult(text, index, searchHits);

--- a/mupdflibrary/src/main/java/com/artifex/mupdfdemo/SearchTaskResult.java
+++ b/mupdflibrary/src/main/java/com/artifex/mupdfdemo/SearchTaskResult.java
@@ -5,10 +5,10 @@ import android.graphics.RectF;
 public class SearchTaskResult {
     public final String txt;
     public final int pageNumber;
-    public final RectF searchBoxes[];
+    public final RectF[] searchBoxes;
     static private SearchTaskResult singleton;
 
-    SearchTaskResult(String _txt, int _pageNumber, RectF _searchBoxes[]) {
+    SearchTaskResult(String _txt, int _pageNumber, RectF[] _searchBoxes) {
         txt = _txt;
         pageNumber = _pageNumber;
         searchBoxes = _searchBoxes;

--- a/sample/src/main/java/com/tekinarslan/sample/PdfFragment.java
+++ b/sample/src/main/java/com/tekinarslan/sample/PdfFragment.java
@@ -82,7 +82,7 @@ public class PdfFragment extends Fragment {
     }
 
 
-    private MuPDFCore openBuffer(byte buffer[]) {
+    private MuPDFCore openBuffer(byte[] buffer) {
         System.out.println("Trying to open byte buffer");
         try {
             core = new MuPDFCore(mContext, buffer);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed